### PR TITLE
feat: implement SMA crossover signal generator (#3)

### DIFF
--- a/src/quant_lab/strategy/__init__.py
+++ b/src/quant_lab/strategy/__init__.py
@@ -1,3 +1,5 @@
 """Strategy layer package for deterministic signal generation."""
 
-__all__: list[str] = []
+from .sma import generate_sma_signals
+
+__all__ = ["generate_sma_signals"]

--- a/src/quant_lab/strategy/sma.py
+++ b/src/quant_lab/strategy/sma.py
@@ -1,0 +1,37 @@
+"""SMA crossover signal generation for Quant Lab v0."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _validate_windows(short_window: int, long_window: int) -> None:
+    if short_window <= 0 or long_window <= 0:
+        raise ValueError("short_window and long_window must be positive integers.")
+    if short_window >= long_window:
+        raise ValueError("short_window must be less than long_window.")
+
+
+def generate_sma_signals(
+    price_data: pd.DataFrame,
+    short_window: int,
+    long_window: int,
+    price_column: str = "close",
+) -> pd.Series:
+    """Generate deterministic long/cash (1/0) SMA crossover signals."""
+    _validate_windows(short_window=short_window, long_window=long_window)
+
+    if price_column not in price_data.columns:
+        raise ValueError(f"Missing required price column: {price_column}")
+    if price_data.empty:
+        raise ValueError("price_data cannot be empty.")
+
+    prices = pd.to_numeric(price_data[price_column], errors="coerce")
+
+    short_sma = prices.rolling(window=short_window, min_periods=short_window).mean()
+    long_sma = prices.rolling(window=long_window, min_periods=long_window).mean()
+
+    signal = (short_sma > long_sma).astype(int)
+    signal = signal.fillna(0).astype(int)
+    signal.name = "signal"
+    return signal

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from quant_lab.strategy import generate_sma_signals  # noqa: E402
+
+
+def test_generate_sma_signals_boundary_behavior() -> None:
+    price_data = pd.DataFrame(
+        {"close": [1, 1, 1, 1, 3, 5, 1]},
+        index=pd.to_datetime(
+            [
+                "2020-01-01",
+                "2020-01-02",
+                "2020-01-03",
+                "2020-01-04",
+                "2020-01-05",
+                "2020-01-06",
+                "2020-01-07",
+            ]
+        ),
+    )
+
+    signal = generate_sma_signals(price_data=price_data, short_window=2, long_window=3)
+
+    assert signal.index.equals(price_data.index)
+    assert set(signal.unique()) <= {0, 1}
+    assert signal.tolist() == [0, 0, 0, 0, 1, 1, 0]
+
+
+def test_generate_sma_signals_uses_custom_price_column() -> None:
+    price_data = pd.DataFrame(
+        {"adj_close": [10, 10, 10, 12, 14]},
+        index=pd.to_datetime(
+            ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05"]
+        ),
+    )
+
+    signal = generate_sma_signals(
+        price_data=price_data,
+        short_window=2,
+        long_window=3,
+        price_column="adj_close",
+    )
+
+    assert signal.index.equals(price_data.index)
+    assert signal.dtype == int
+
+
+@pytest.mark.parametrize(
+    ("short_window", "long_window"),
+    [(0, 3), (2, 0), (3, 3), (4, 3)],
+)
+def test_generate_sma_signals_validates_window_inputs(
+    short_window: int, long_window: int
+) -> None:
+    price_data = pd.DataFrame(
+        {"close": [1, 2, 3]},
+        index=pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
+
+    with pytest.raises(ValueError):
+        generate_sma_signals(
+            price_data=price_data,
+            short_window=short_window,
+            long_window=long_window,
+        )
+
+
+def test_generate_sma_signals_requires_column_and_non_empty_data() -> None:
+    with pytest.raises(ValueError, match="Missing required price column"):
+        generate_sma_signals(
+            price_data=pd.DataFrame({"open": [1]}),
+            short_window=1,
+            long_window=2,
+        )
+
+    with pytest.raises(ValueError, match="price_data cannot be empty"):
+        generate_sma_signals(
+            price_data=pd.DataFrame({"close": []}),
+            short_window=1,
+            long_window=2,
+        )


### PR DESCRIPTION
## Linked Issue

Fixes #3

## Summary

- Implement SMA crossover strategy module in `src/quant_lab/strategy/sma.py`.
- Export strategy API from `src/quant_lab/strategy/__init__.py`.
- Add unit tests in `tests/test_strategy.py` for:
  - crossover boundary behavior,
  - signal contract (`0/1` values with aligned index),
  - custom price column support,
  - invalid window and missing data validation.

## How To Verify

- Commands run:
  - `make check` (not available in this environment)
  - `ruff format --check .`
  - `ruff check .`
  - `pytest -q`
- Issue-specific checks:
  - `pytest -q tests -k strategy`
  - `python -c "import sys; sys.path.insert(0, 'src'); from quant_lab.strategy import generate_sma_signals; print(generate_sma_signals.__name__)"`

## Scope Check

- [x] Changes are scoped only to the linked issue.
- [x] No unrelated refactors are included.
- [x] Documentation updated where relevant.
