### PR TITLE
feat: implement deterministic long-cash engine (#4)

### DIFF
--- a/src/quant_lab/engine/__init__.py
+++ b/src/quant_lab/engine/__init__.py
@@ -1,3 +1,5 @@
 """Engine layer package for position and equity simulation."""
 
-__all__: list[str] = []
+from .backtest import run_backtest
+
+__all__ = ["run_backtest"]

--- a/src/quant_lab/engine/backtest.py
+++ b/src/quant_lab/engine/backtest.py
@@ -1,0 +1,74 @@
+"""Deterministic long/cash backtest engine for Quant Lab v0."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from quant_lab.contracts import BacktestResult
+
+
+def _validate_inputs(
+    price_data: pd.DataFrame,
+    signals: pd.Series,
+    initial_cash: float,
+    min_required_bars: int | None,
+    price_column: str,
+) -> None:
+    if initial_cash <= 0:
+        raise ValueError("initial_cash must be positive.")
+    if price_data.empty:
+        raise ValueError("price_data cannot be empty.")
+    if price_column not in price_data.columns:
+        raise ValueError(f"Missing required price column: {price_column}")
+    if not price_data.index.equals(signals.index):
+        raise ValueError("signals index must match price_data index.")
+
+    signal_values = set(pd.to_numeric(signals, errors="coerce").dropna().astype(int))
+    if not signal_values.issubset({0, 1}):
+        raise ValueError("signals must contain only 0/1 values.")
+
+    if min_required_bars is not None:
+        if min_required_bars <= 0:
+            raise ValueError("min_required_bars must be positive when provided.")
+        if len(price_data) < min_required_bars:
+            raise ValueError(
+                "insufficient bars for configured windows: "
+                f"need at least {min_required_bars}, got {len(price_data)}"
+            )
+
+
+def run_backtest(
+    price_data: pd.DataFrame,
+    signals: pd.Series,
+    initial_cash: float,
+    min_required_bars: int | None = None,
+    price_column: str = "close",
+) -> BacktestResult:
+    """Run a deterministic long/cash backtest with no-lookahead execution."""
+    _validate_inputs(
+        price_data=price_data,
+        signals=signals,
+        initial_cash=initial_cash,
+        min_required_bars=min_required_bars,
+        price_column=price_column,
+    )
+
+    prices = pd.to_numeric(price_data[price_column], errors="coerce")
+    asset_returns = prices.pct_change().fillna(0.0)
+
+    raw_positions = pd.to_numeric(signals, errors="coerce").fillna(0).astype(int)
+    raw_positions = raw_positions.clip(lower=0, upper=1)
+    executed_positions = raw_positions.shift(1, fill_value=0).astype(int)
+    executed_positions.name = "position"
+
+    strategy_returns = (asset_returns * executed_positions).fillna(0.0)
+    strategy_returns.name = "strategy_return"
+
+    equity_curve = (1.0 + strategy_returns).cumprod() * float(initial_cash)
+    equity_curve.name = "equity"
+
+    return BacktestResult(
+        equity_curve=equity_curve,
+        strategy_returns=strategy_returns,
+        positions=executed_positions,
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from quant_lab.engine import run_backtest  # noqa: E402
+
+
+def test_run_backtest_no_lookahead_and_alignment() -> None:
+    price_data = pd.DataFrame(
+        {"close": [100.0, 110.0, 110.0, 121.0]},
+        index=pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"]),
+    )
+    signals = pd.Series([1, 1, 0, 1], index=price_data.index, name="signal")
+
+    result = run_backtest(price_data=price_data, signals=signals, initial_cash=100.0)
+
+    assert result.equity_curve.index.equals(price_data.index)
+    assert result.strategy_returns.index.equals(price_data.index)
+    assert result.positions.index.equals(price_data.index)
+    assert result.positions.tolist() == [0, 1, 1, 0]
+    assert result.strategy_returns.round(6).tolist() == [0.0, 0.1, 0.0, 0.0]
+    assert result.equity_curve.round(6).tolist() == [100.0, 110.0, 110.0, 110.0]
+
+
+def test_run_backtest_rejects_invalid_signal_values() -> None:
+    price_data = pd.DataFrame(
+        {"close": [1.0, 2.0, 3.0]},
+        index=pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
+    signals = pd.Series([0, 2, 1], index=price_data.index)
+
+    with pytest.raises(ValueError, match="signals must contain only 0/1"):
+        run_backtest(price_data=price_data, signals=signals, initial_cash=100.0)
+
+
+def test_run_backtest_requires_sufficient_bars_when_configured() -> None:
+    price_data = pd.DataFrame(
+        {"close": [1.0, 2.0, 3.0]},
+        index=pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
+    signals = pd.Series([0, 1, 1], index=price_data.index)
+
+    with pytest.raises(ValueError, match="insufficient bars for configured windows"):
+        run_backtest(
+            price_data=price_data,
+            signals=signals,
+            initial_cash=100.0,
+            min_required_bars=5,
+        )
+
+
+def test_run_backtest_validates_index_alignment() -> None:
+    price_data = pd.DataFrame(
+        {"close": [1.0, 2.0, 3.0]},
+        index=pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
+    signals = pd.Series(
+        [0, 1, 1], index=pd.to_datetime(["2020-01-02", "2020-01-03", "2020-01-04"])
+    )
+
+    with pytest.raises(ValueError, match="signals index must match price_data index"):
+        run_backtest(price_data=price_data, signals=signals, initial_cash=100.0)


### PR DESCRIPTION
## Linked Issue

Fixes #4

## Summary

- Implement deterministic backtest engine in `src/quant_lab/engine/backtest.py`.
- Add `run_backtest` export in `src/quant_lab/engine/__init__.py`.
- Add unit tests in `tests/test_engine.py` covering:
  - no-lookahead position shifting,
  - aligned output series,
  - invalid signal validation,
  - insufficient-bars validation,
  - index alignment validation.

## How To Verify

- Commands run:
  - `make check` (not available in this environment)
  - `ruff format --check .`
  - `ruff check .`
  - `pytest -q`
- Issue-specific checks:
  - `pytest -q tests -k engine`
  - `python -c "import sys; sys.path.insert(0, 'src'); from quant_lab.engine import run_backtest; print(run_backtest.__name__)"`

## Scope Check

- [x] Changes are scoped only to the linked issue.
- [x] No unrelated refactors are included.
- [x] Documentation updated where relevant.
