### PR TITLE
feat: implement performance metrics module (#5)

### DIFF
--- a/src/quant_lab/metrics/__init__.py
+++ b/src/quant_lab/metrics/__init__.py
@@ -1,3 +1,5 @@
 """Metrics layer package for risk and performance calculations."""
 
-__all__: list[str] = []
+from .performance import compute_performance_metrics
+
+__all__ = ["compute_performance_metrics"]

--- a/src/quant_lab/metrics/performance.py
+++ b/src/quant_lab/metrics/performance.py
@@ -1,0 +1,60 @@
+"""Performance metrics for Quant Lab v0 backtests."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+
+def _compute_cagr(equity_curve: pd.Series) -> float:
+    start_value = float(equity_curve.iloc[0])
+    end_value = float(equity_curve.iloc[-1])
+    periods = len(equity_curve) - 1
+    if periods <= 0:
+        return 0.0
+
+    years = periods / 252.0
+    if years <= 0:
+        return 0.0
+    return (end_value / start_value) ** (1.0 / years) - 1.0
+
+
+def _compute_sharpe(strategy_returns: pd.Series) -> float:
+    clean_returns = pd.to_numeric(strategy_returns, errors="coerce").fillna(0.0)
+    std = float(clean_returns.std(ddof=0))
+    if std == 0.0:
+        return 0.0
+    mean = float(clean_returns.mean())
+    return (mean / std) * math.sqrt(252.0)
+
+
+def _compute_max_drawdown(equity_curve: pd.Series) -> float:
+    running_peak = equity_curve.cummax()
+    drawdown = (equity_curve / running_peak) - 1.0
+    return float(drawdown.min())
+
+
+def compute_performance_metrics(
+    equity_curve: pd.Series,
+    strategy_returns: pd.Series,
+) -> dict[str, float]:
+    """Compute core v0 metrics from equity curve and strategy returns."""
+    if equity_curve.empty or strategy_returns.empty:
+        raise ValueError("equity_curve and strategy_returns must be non-empty.")
+    if not equity_curve.index.equals(strategy_returns.index):
+        raise ValueError("equity_curve and strategy_returns must share the same index.")
+
+    equity_numeric = pd.to_numeric(equity_curve, errors="coerce")
+    if equity_numeric.isna().any():
+        raise ValueError("equity_curve contains non-numeric values.")
+    if float(equity_numeric.iloc[0]) <= 0:
+        raise ValueError("equity_curve must start above zero.")
+    if (equity_numeric <= 0).any():
+        raise ValueError("equity_curve must remain positive.")
+
+    return {
+        "cagr": float(_compute_cagr(equity_numeric)),
+        "sharpe": float(_compute_sharpe(strategy_returns)),
+        "max_drawdown": float(_compute_max_drawdown(equity_numeric)),
+    }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from quant_lab.metrics import compute_performance_metrics  # noqa: E402
+
+
+def test_compute_performance_metrics_known_values() -> None:
+    index = pd.to_datetime(
+        ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05"]
+    )
+    equity_curve = pd.Series([100.0, 110.0, 99.0, 118.8, 130.68], index=index)
+    strategy_returns = pd.Series([0.0, 0.1, -0.1, 0.2, 0.1], index=index)
+
+    metrics = compute_performance_metrics(
+        equity_curve=equity_curve,
+        strategy_returns=strategy_returns,
+    )
+
+    periods = len(equity_curve) - 1
+    expected_cagr = (130.68 / 100.0) ** (1.0 / (periods / 252.0)) - 1.0
+    expected_sharpe = (
+        strategy_returns.mean() / strategy_returns.std(ddof=0)
+    ) * math.sqrt(252.0)
+    expected_max_drawdown = -0.1
+
+    assert pytest.approx(metrics["cagr"], rel=1e-9) == expected_cagr
+    assert pytest.approx(metrics["sharpe"], rel=1e-9) == expected_sharpe
+    assert pytest.approx(metrics["max_drawdown"], rel=1e-12) == expected_max_drawdown
+
+
+def test_compute_performance_metrics_returns_zero_sharpe_on_zero_volatility() -> None:
+    index = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
+    equity_curve = pd.Series([100.0, 100.0, 100.0], index=index)
+    strategy_returns = pd.Series([0.0, 0.0, 0.0], index=index)
+
+    metrics = compute_performance_metrics(
+        equity_curve=equity_curve,
+        strategy_returns=strategy_returns,
+    )
+
+    assert metrics["sharpe"] == 0.0
+    assert metrics["cagr"] == 0.0
+    assert metrics["max_drawdown"] == 0.0
+
+
+def test_compute_performance_metrics_validates_inputs() -> None:
+    index = pd.to_datetime(["2020-01-01", "2020-01-02"])
+    good_equity = pd.Series([100.0, 101.0], index=index)
+    good_returns = pd.Series([0.0, 0.01], index=index)
+
+    with pytest.raises(ValueError, match="must be non-empty"):
+        compute_performance_metrics(pd.Series(dtype=float), good_returns)
+
+    with pytest.raises(ValueError, match="must share the same index"):
+        compute_performance_metrics(
+            good_equity,
+            pd.Series([0.0, 0.01], index=pd.to_datetime(["2020-01-02", "2020-01-03"])),
+        )
+
+    with pytest.raises(ValueError, match="must start above zero"):
+        compute_performance_metrics(
+            pd.Series([0.0, 1.0], index=index),
+            good_returns,
+        )
+
+    with pytest.raises(ValueError, match="must remain positive"):
+        compute_performance_metrics(
+            pd.Series([100.0, -1.0], index=index),
+            good_returns,
+        )


### PR DESCRIPTION
## Linked Issue

Fixes #5

## Summary

- Implement core performance metrics in `src/quant_lab/metrics/performance.py`:
  - CAGR from equity curve duration and growth,
  - Sharpe Ratio from daily returns with annualization constant 252,
  - Maximum Drawdown from rolling equity peak.
- Export `compute_performance_metrics` via `src/quant_lab/metrics/__init__.py`.
- Add unit tests in `tests/test_metrics.py` for:
  - known-value correctness on synthetic series,
  - zero-volatility Sharpe returning `0.0`,
  - input validation behavior.

## How To Verify

- Commands run:
  - `make check` (not available in this environment)
  - `ruff format --check .`
  - `ruff check .`
  - `pytest -q`
- Issue-specific checks:
  - `pytest -q tests -k metrics`
  - `python -c "import sys; sys.path.insert(0, 'src'); from quant_lab.metrics import compute_performance_metrics; print(compute_performance_metrics.__name__)"`

## Scope Check

- [x] Changes are scoped only to the linked issue.
- [x] No unrelated refactors are included.
- [x] Documentation updated where relevant.
