### PR TITLE
feat: implement reporting artifacts module (#6)

### DIFF
--- a/src/quant_lab/reporting/__init__.py
+++ b/src/quant_lab/reporting/__init__.py
@@ -1,3 +1,5 @@
 """Reporting layer package for artifact persistence and visualization."""
 
-__all__: list[str] = []
+from .artifacts import build_run_artifacts, write_run_artifacts
+
+__all__ = ["build_run_artifacts", "write_run_artifacts"]

--- a/src/quant_lab/reporting/artifacts.py
+++ b/src/quant_lab/reporting/artifacts.py
@@ -1,0 +1,75 @@
+"""Artifact persistence utilities for Quant Lab v0 reporting."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from quant_lab.contracts import RunArtifacts
+
+
+def build_run_artifacts(output_dir: str | Path) -> RunArtifacts:
+    """Build deterministic artifact paths for a reporting run."""
+    base_dir = Path(output_dir)
+    return RunArtifacts(
+        metrics_path=base_dir / "metrics.json",
+        equity_curve_path=base_dir / "equity_curve.png",
+        metadata_path=base_dir / "run_metadata.json",
+    )
+
+
+def _ensure_output_dir(paths: RunArtifacts) -> None:
+    paths.metrics_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _write_metrics(metrics: Mapping[str, float], metrics_path: Path) -> None:
+    payload = {key: float(value) for key, value in sorted(metrics.items())}
+    metrics_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+
+def _write_metadata(metadata: Mapping[str, Any], metadata_path: Path) -> None:
+    metadata_path.write_text(
+        json.dumps(dict(metadata), indent=2, sort_keys=True, default=str),
+        encoding="utf-8",
+    )
+
+
+def _write_equity_curve_plot(equity_curve: pd.Series, equity_curve_path: Path) -> None:
+    figure, axis = plt.subplots(figsize=(10, 4))
+    axis.plot(equity_curve.index, equity_curve.values, label="equity")
+    axis.set_title("Equity Curve")
+    axis.set_xlabel("Date")
+    axis.set_ylabel("Equity")
+    axis.grid(True, alpha=0.3)
+    axis.legend()
+    figure.tight_layout()
+    figure.savefig(equity_curve_path, dpi=144)
+    plt.close(figure)
+
+
+def write_run_artifacts(
+    metrics: Mapping[str, float],
+    equity_curve: pd.Series,
+    metadata: Mapping[str, Any],
+    output_dir: str | Path,
+) -> RunArtifacts:
+    """Write metrics, metadata, and equity curve plot artifacts."""
+    if equity_curve.empty:
+        raise ValueError("equity_curve must be non-empty.")
+
+    artifacts = build_run_artifacts(output_dir=output_dir)
+    _ensure_output_dir(artifacts)
+    _write_metrics(metrics=metrics, metrics_path=artifacts.metrics_path)
+    _write_metadata(metadata=metadata, metadata_path=artifacts.metadata_path)
+    _write_equity_curve_plot(
+        equity_curve=equity_curve,
+        equity_curve_path=artifacts.equity_curve_path,
+    )
+    return artifacts

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from quant_lab.reporting import build_run_artifacts, write_run_artifacts  # noqa: E402
+
+
+def _output_dir(test_name: str) -> Path:
+    output_dir = PROJECT_ROOT / "outputs" / "tests" / test_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def test_build_run_artifacts_uses_deterministic_filenames() -> None:
+    output_dir = _output_dir("reporting_filenames")
+    artifacts = build_run_artifacts(output_dir=output_dir)
+
+    assert artifacts.metrics_path == output_dir / "metrics.json"
+    assert artifacts.equity_curve_path == output_dir / "equity_curve.png"
+    assert artifacts.metadata_path == output_dir / "run_metadata.json"
+
+
+def test_write_run_artifacts_writes_expected_files() -> None:
+    index = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
+    equity_curve = pd.Series([100.0, 105.0, 103.0], index=index)
+    metrics = {"sharpe": 1.2, "cagr": 0.15, "max_drawdown": -0.02}
+    metadata = {"symbol": "SPY", "short_window": 20, "long_window": 50}
+
+    output_dir = _output_dir("reporting_write")
+    artifacts = write_run_artifacts(
+        metrics=metrics,
+        equity_curve=equity_curve,
+        metadata=metadata,
+        output_dir=output_dir,
+    )
+
+    assert artifacts.metrics_path.exists()
+    assert artifacts.metadata_path.exists()
+    assert artifacts.equity_curve_path.exists()
+
+    metrics_payload = json.loads(artifacts.metrics_path.read_text(encoding="utf-8"))
+    metadata_payload = json.loads(artifacts.metadata_path.read_text(encoding="utf-8"))
+
+    assert list(metrics_payload.keys()) == ["cagr", "max_drawdown", "sharpe"]
+    assert metrics_payload["cagr"] == pytest.approx(0.15)
+    assert metadata_payload["symbol"] == "SPY"
+
+
+def test_write_run_artifacts_rejects_empty_equity_curve() -> None:
+    with pytest.raises(ValueError, match="equity_curve must be non-empty"):
+        write_run_artifacts(
+            metrics={"cagr": 0.0, "sharpe": 0.0, "max_drawdown": 0.0},
+            equity_curve=pd.Series(dtype=float),
+            metadata={},
+            output_dir=_output_dir("reporting_empty_equity"),
+        )


### PR DESCRIPTION
## Linked Issue

Fixes #6

## Summary

- Implement reporting artifact persistence in `src/quant_lab/reporting/artifacts.py`.
- Add deterministic artifact path builder (`metrics.json`, `equity_curve.png`, `run_metadata.json`).
- Add `write_run_artifacts` orchestration to write:
  - metrics JSON,
  - run metadata JSON,
  - equity curve plot image.
- Export reporting APIs via `src/quant_lab/reporting/__init__.py`.
- Add tests in `tests/test_reporting.py` for deterministic filenames, artifact creation/content, and empty equity validation.

## How To Verify

- Commands run:
  - `make check` (not available in this environment)
  - `ruff format --check .`
  - `ruff check .`
  - `pytest -q`
- Issue-specific checks:
  - `pytest -q tests -k reporting`
  - `python -c "import sys; sys.path.insert(0, 'src'); from quant_lab.reporting import build_run_artifacts, write_run_artifacts; print(build_run_artifacts.__name__, write_run_artifacts.__name__)"`

## Scope Check

- [x] Changes are scoped only to the linked issue.
- [x] No unrelated refactors are included.
- [x] Documentation updated where relevant.
