### PR TITLE
feat: implement CLI backtest orchestration (#7)

### DIFF
--- a/src/quant_lab/cli.py
+++ b/src/quant_lab/cli.py
@@ -1,9 +1,18 @@
-"""CLI scaffold for Quant Lab v0."""
+"""CLI entrypoint for Quant Lab v0 backtest orchestration."""
 
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
+
+import pandas as pd
+
+from quant_lab.data import fetch_price_data
+from quant_lab.engine import run_backtest
+from quant_lab.metrics import compute_performance_metrics
+from quant_lab.reporting import write_run_artifacts
+from quant_lab.strategy import generate_sma_signals
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -22,18 +31,80 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_backtest_args(args: argparse.Namespace) -> None:
+    if args.short_window <= 0 or args.long_window <= 0:
+        raise ValueError("short_window and long_window must be positive integers.")
+    if args.short_window >= args.long_window:
+        raise ValueError("short_window must be less than long_window.")
+    if args.initial_cash <= 0:
+        raise ValueError("initial_cash must be positive.")
+
+    parsed_start = pd.Timestamp(args.start)
+    parsed_end = pd.Timestamp(args.end)
+    if parsed_start > parsed_end:
+        raise ValueError("start date must be on or before end date.")
+
+
+def _run_backtest_command(args: argparse.Namespace) -> int:
+    _validate_backtest_args(args)
+
+    price_data = fetch_price_data(symbol=args.symbol, start=args.start, end=args.end)
+    if len(price_data) < args.long_window:
+        raise ValueError(
+            "insufficient bars for configured windows: "
+            f"need at least {args.long_window}, got {len(price_data)}"
+        )
+
+    signals = generate_sma_signals(
+        price_data=price_data,
+        short_window=args.short_window,
+        long_window=args.long_window,
+    )
+    result = run_backtest(
+        price_data=price_data,
+        signals=signals,
+        initial_cash=args.initial_cash,
+        min_required_bars=args.long_window,
+    )
+    metrics = compute_performance_metrics(
+        equity_curve=result.equity_curve,
+        strategy_returns=result.strategy_returns,
+    )
+    artifacts = write_run_artifacts(
+        metrics=metrics,
+        equity_curve=result.equity_curve,
+        metadata={
+            "symbol": args.symbol,
+            "start": args.start,
+            "end": args.end,
+            "short_window": args.short_window,
+            "long_window": args.long_window,
+            "initial_cash": args.initial_cash,
+            "output_dir": args.output_dir,
+        },
+        output_dir=args.output_dir,
+    )
+
+    print("Backtest complete.")
+    print(f"metrics: {artifacts.metrics_path}")
+    print(f"equity_curve: {artifacts.equity_curve_path}")
+    print(f"run_metadata: {artifacts.metadata_path}")
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    """Execute CLI entrypoint for scaffold-only v0 package."""
+    """Execute CLI entrypoint for Quant Lab workflows."""
     parser = build_parser()
     args = parser.parse_args(argv)
     if args.command != "backtest":
         parser.print_help()
         return 2
 
-    print(
-        "Backtest command scaffolded. Functional implementation is tracked in QL-007."
-    )
-    return 0
+    try:
+        return _run_backtest_command(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+import quant_lab.cli as cli  # noqa: E402
+from quant_lab.contracts import RunArtifacts  # noqa: E402
+
+
+def _valid_argv() -> list[str]:
+    return [
+        "backtest",
+        "--symbol",
+        "SPY",
+        "--start",
+        "2020-01-01",
+        "--end",
+        "2020-01-05",
+        "--short-window",
+        "2",
+        "--long-window",
+        "3",
+        "--initial-cash",
+        "10000",
+        "--output-dir",
+        "outputs/verify_cli",
+    ]
+
+
+def test_cli_backtest_success_orchestrates_pipeline(monkeypatch, capsys) -> None:
+    index = pd.to_datetime(
+        ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05"]
+    )
+    price_data = pd.DataFrame(
+        {
+            "open": [1, 2, 3, 4, 5],
+            "high": [1, 2, 3, 4, 5],
+            "low": [1, 2, 3, 4, 5],
+            "close": [1, 2, 3, 4, 5],
+            "adj_close": [1, 2, 3, 4, 5],
+            "volume": [1, 2, 3, 4, 5],
+        },
+        index=index,
+    )
+    signal = pd.Series([0, 0, 1, 1, 1], index=index)
+    strategy_returns = pd.Series([0.0, 0.0, 0.1, 0.0, 0.1], index=index)
+    equity_curve = pd.Series([10000.0, 10000.0, 11000.0, 11000.0, 12100.0], index=index)
+    artifacts = RunArtifacts(
+        metrics_path=Path("outputs/verify_cli/metrics.json"),
+        equity_curve_path=Path("outputs/verify_cli/equity_curve.png"),
+        metadata_path=Path("outputs/verify_cli/run_metadata.json"),
+    )
+
+    class _Result:
+        def __init__(self) -> None:
+            self.equity_curve = equity_curve
+            self.strategy_returns = strategy_returns
+            self.positions = signal
+
+    monkeypatch.setattr(cli, "fetch_price_data", lambda **_: price_data)
+    monkeypatch.setattr(cli, "generate_sma_signals", lambda **_: signal)
+    monkeypatch.setattr(cli, "run_backtest", lambda **_: _Result())
+    monkeypatch.setattr(
+        cli,
+        "compute_performance_metrics",
+        lambda **_: {"cagr": 0.1, "sharpe": 1.2, "max_drawdown": -0.05},
+    )
+    monkeypatch.setattr(cli, "write_run_artifacts", lambda **_: artifacts)
+
+    exit_code = cli.main(_valid_argv())
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Backtest complete." in output
+    assert "metrics:" in output
+
+
+def test_cli_backtest_rejects_invalid_window_relationship(capsys) -> None:
+    argv = _valid_argv()
+    argv[argv.index("--short-window") + 1] = "5"
+    argv[argv.index("--long-window") + 1] = "3"
+
+    exit_code = cli.main(argv)
+    error_output = capsys.readouterr().err
+
+    assert exit_code == 1
+    assert "short_window must be less than long_window" in error_output
+
+
+def test_cli_backtest_rejects_invalid_date_order(capsys) -> None:
+    argv = _valid_argv()
+    argv[argv.index("--start") + 1] = "2020-01-10"
+    argv[argv.index("--end") + 1] = "2020-01-01"
+
+    exit_code = cli.main(argv)
+    error_output = capsys.readouterr().err
+
+    assert exit_code == 1
+    assert "start date must be on or before end date" in error_output
+
+
+def test_cli_backtest_fails_when_bars_are_insufficient(monkeypatch, capsys) -> None:
+    index = pd.to_datetime(["2020-01-01", "2020-01-02"])
+    price_data = pd.DataFrame(
+        {
+            "open": [1, 2],
+            "high": [1, 2],
+            "low": [1, 2],
+            "close": [1, 2],
+            "adj_close": [1, 2],
+            "volume": [1, 2],
+        },
+        index=index,
+    )
+
+    monkeypatch.setattr(cli, "fetch_price_data", lambda **_: price_data)
+
+    exit_code = cli.main(_valid_argv())
+    error_output = capsys.readouterr().err
+
+    assert exit_code == 1
+    assert "insufficient bars for configured windows" in error_output


### PR DESCRIPTION
## Linked Issue

Fixes #7

## Summary

- Replace CLI scaffold with functional backtest orchestration in `src/quant_lab/cli.py`.
- Add CLI validation for:
  - `short_window`/`long_window` positivity,
  - `short_window < long_window`,
  - positive `initial_cash`,
  - `start <= end`.
- Wire CLI pipeline modules in order:
  - data fetch/normalize,
  - strategy signal generation,
  - engine simulation,
  - metrics computation,
  - reporting artifact write.
- Add explicit insufficient-bars check and non-zero error exit behavior with clear messages.
- Add `tests/test_cli.py` covering success orchestration and failure paths.

## How To Verify

- Commands run:
  - `make check` (not available in this environment)
  - `ruff format --check .`
  - `ruff check .`
  - `pytest -q`
- Issue-specific checks:
  - `pytest -q tests -k cli`
  - `python -m quant_lab.cli backtest --symbol SPY --start 2020-01-01 --end 2021-12-31 --short-window 20 --long-window 50 --initial-cash 10000 --output-dir outputs/verify_cli`

## Scope Check

- [x] Changes are scoped only to the linked issue.
- [x] No unrelated refactors are included.
- [x] Documentation updated where relevant.
