### PR TITLE
chore: align v0 docs with implemented behavior (#9)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@ Responsibilities:
 - External fetch failures:
   - Surface data-source error in CLI with non-zero exit.
 - Contract violations:
-  - Raise typed runtime error with context for debug/test assertions.
+  - Raise explicit user-facing validation errors (current implementation uses `ValueError` messages).
 
 ## 7. Testing Strategy Map
 
@@ -160,9 +160,9 @@ Responsibilities:
   - artifact creation,
   - repeat-run output consistency.
 
-## 8. Project Structure Target
+## 8. Project Structure
 
-Planned v0 module layout:
+Current v0 module layout:
 
 - `src/quant_lab/data/`
 - `src/quant_lab/strategy/`
@@ -172,4 +172,5 @@ Planned v0 module layout:
 - `src/quant_lab/cli.py`
 - `tests/unit/`
 - `tests/integration/`
+- `tests/fixtures/`
 - `outputs/` (runtime artifacts, not committed unless explicitly required)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Expected outputs:
 
 - A metrics artifact containing CAGR, Sharpe Ratio, and Max Drawdown.
 - An equity curve plot image.
-- Run metadata (parameters and run context).
+- Run metadata (CLI input parameters).
 
 ## Repository Map
 
@@ -78,6 +78,29 @@ Expected outputs:
 - Keep PR scope atomic and limited to the linked issue.
 - Run `make check` before push/PR update.
 - Use PR body format from `.github/pull_request_template.md` with `Fixes #<issue-number>`.
+
+### Verification Commands
+
+Core quality gate:
+
+```powershell
+make check
+```
+
+Fallback in environments without `make`:
+
+```powershell
+ruff format --check .
+ruff check .
+pytest -q
+```
+
+Additional deterministic suite checks:
+
+```powershell
+pytest -q tests/unit
+pytest -q tests/integration
+```
 
 ## Planning and Issue Automation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -78,7 +78,7 @@ Out of scope for v0:
 Each run must produce:
 - Metrics artifact (machine-readable, e.g. JSON).
 - Equity curve plot image (e.g. PNG).
-- Run metadata artifact capturing run parameters and timestamps/context used for reproducibility.
+- Run metadata artifact capturing run parameters used for reproducibility.
 
 ### FR-6 CLI Public Interface
 
@@ -164,4 +164,8 @@ CLI behavior:
 
 ### Quality Gate
 
-- `make check` passes locally and in CI.
+- `make check` passes locally and in CI when `make` is available.
+- Equivalent fallback commands pass in environments without `make`:
+  - `ruff format --check .`
+  - `ruff check .`
+  - `pytest -q`


### PR DESCRIPTION
## Linked Issue

Fixes #9

## Summary

- Align `README.md`, `SPEC.md`, and `ARCHITECTURE.md` with currently implemented v0 behavior.
- Update reporting documentation to reflect that run metadata stores CLI input parameters.
- Add explicit verification section in README with `make check` and fallback commands.
- Update SPEC quality gate wording for environments without `make`.
- Update ARCHITECTURE error-handling wording to match current implementation (`ValueError`-based validation errors).
- Update architecture structure section to reflect current module/test layout including `tests/fixtures/`.

## How To Verify

- Commands run:
  - `make check` (not available in this environment)
  - `ruff format --check .`
  - `ruff check .`
  - `pytest -q`
- Issue-specific checks:
  - `python automation/create_issues.py --input planning/issues/v0.json --mode dry-run --milestone v0`
  - `rg "long/cash" README.md SPEC.md ARCHITECTURE.md`

## Scope Check

- [x] Changes are scoped only to the linked issue.
- [x] No unrelated refactors are included.
- [x] Documentation updated where relevant.
