### PR TITLE
fix: handle yfinance multiindex columns in normalization (#19)

### DIFF
--- a/src/quant_lab/data/market_data.py
+++ b/src/quant_lab/data/market_data.py
@@ -16,6 +16,30 @@ REQUIRED_COLUMNS: tuple[str, ...] = (
 )
 
 
+def _normalize_column_name(column: object) -> str:
+    return str(column).strip().lower().replace(" ", "_")
+
+
+def _canonicalize_columns(columns: pd.Index) -> list[str]:
+    if isinstance(columns, pd.MultiIndex):
+        required = set(REQUIRED_COLUMNS)
+        for level in range(columns.nlevels):
+            normalized_level = [
+                _normalize_column_name(value)
+                for value in columns.get_level_values(level)
+            ]
+            if required.issubset(set(normalized_level)):
+                return normalized_level
+
+        flat_columns: list[str] = []
+        for entry in columns.to_flat_index():
+            joined = "_".join(str(part) for part in entry if str(part).strip())
+            flat_columns.append(_normalize_column_name(joined))
+        return flat_columns
+
+    return [_normalize_column_name(col) for col in columns]
+
+
 def _default_downloader(symbol: str, start: str, end: str) -> pd.DataFrame:
     import yfinance as yf
 
@@ -24,6 +48,7 @@ def _default_downloader(symbol: str, start: str, end: str) -> pd.DataFrame:
         start=start,
         end=end,
         auto_adjust=False,
+        multi_level_index=False,
         progress=False,
     )
 
@@ -34,9 +59,7 @@ def normalize_price_data(raw_data: pd.DataFrame) -> pd.DataFrame:
         raise ValueError("No price data returned.")
 
     normalized = raw_data.copy()
-    normalized.columns = [
-        str(col).strip().lower().replace(" ", "_") for col in normalized.columns
-    ]
+    normalized.columns = _canonicalize_columns(normalized.columns)
 
     missing_columns = [col for col in REQUIRED_COLUMNS if col not in normalized.columns]
     if missing_columns:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -68,6 +68,27 @@ def test_normalize_price_data_requires_expected_columns() -> None:
         normalize_price_data(raw)
 
 
+def test_normalize_price_data_accepts_multiindex_columns() -> None:
+    raw = pd.DataFrame(
+        [[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], [10, 20, 30]],
+        index=["Open", "High", "Low", "Close", "Adj Close", "Volume"],
+        columns=pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    ).T
+    raw.columns = pd.MultiIndex.from_product([raw.columns, ["SPY"]])
+
+    normalized = normalize_price_data(raw)
+
+    assert list(normalized.columns) == [
+        "open",
+        "high",
+        "low",
+        "close",
+        "adj_close",
+        "volume",
+    ]
+    assert len(normalized) == 3
+
+
 def test_fetch_price_data_uses_downloader_and_normalizes() -> None:
     def fake_downloader(symbol: str, start: str, end: str) -> pd.DataFrame:
         assert symbol == "SPY"


### PR DESCRIPTION
Fixes #19

## Summary
- handle yfinance MultiIndex column layouts in `normalize_price_data` by selecting the level that contains canonical OHLCV fields before validation
- set `multi_level_index=False` in the default yfinance downloader to prefer flat columns
- add a regression test covering MultiIndex columns so schema drift is caught by the data test suite

## How to Verify
- `make check` (or fallback when `make` is unavailable)
- `ruff format --check .`
- `ruff check .`
- `pytest -q`

## Local Checks
- `make check` could not run in this environment because `make` is not installed
- ran fallback checks successfully: `ruff format --check .`, `ruff check .`, `pytest -q`
